### PR TITLE
Fix User Atlas Avatars For Mapmaking Posts

### DIFF
--- a/src/new-map-releases/index.js
+++ b/src/new-map-releases/index.js
@@ -365,7 +365,7 @@ const fetchAtlasData = async (atlasId) => {
 
     const description = body.content;
     const authorName = body.username;
-    const avatarBlobId = body.avatarBlobId ? body.avatarBlobId : "3601416389886209189";
+    const avatarBlobId = body.avatar_blob_id ? body.avatar_blob_id : "3601416389886209189";
     const authorAvatar = `${baseUrl}?qa=image&qa_blobid=${avatarBlobId}&qa_size=32.png`;
 
     if (body.type === "Q_HIDDEN") {


### PR DESCRIPTION
Small update to use the right attribute (is that the right word?) to get a user's avatar.

Ran bot on my own server to test the change:
![image](https://github.com/user-attachments/assets/3e0824f2-1cac-4f5b-a371-59a774566b8b)


Seems like everything is working